### PR TITLE
lhospital und rehtschreibfehler korrigiert

### DIFF
--- a/uebung_2/uebung.tex
+++ b/uebung_2/uebung.tex
@@ -27,7 +27,7 @@
 
 \subsection*{Aufgabe 1}
 
-\begin{enumerate}[(a)]
+\begin{enumerate}[a)]
   \item Es gilt:
     \begin{align*}
       2^{n+d} = 2^d \cdot 2^n
@@ -113,21 +113,23 @@ e ^{n} \notin \mathcal{O}(n^{c})  \quad \forall c \in \mathrm{N}
 \end{align*}
 Es wird nun der Limes betrachtet.
 \begin{align*}
-\lim\limits_{n \rightarrow \infty}{\dfrac{e^{n}}{n^{c}}} \Rightarrow \infty
+\lim\limits_{n \rightarrow \infty}{e^{n}} = 
+  \lim\limits_{n \rightarrow \infty}{n^c} = \infty
 \end{align*}
-Da der Grenzwert $\infty$ beträgt, wird L`Hospital verwendet.
+Da beide Grenzwert $\infty$ betragen, wird L`Hospital verwendet.
 \begin{align*}
 \lim\limits_{n \rightarrow \infty}{\dfrac{e^{n}}{n^{c}}} &= \lim\limits_{n \rightarrow \infty}{\dfrac{e^{n}}{c \cdot n^{c - 1}}} = \lim\limits_{n \rightarrow \infty}{\dfrac{e^{n}}{c \cdot (c-1) \cdot n^{c - 2}}} = \ldots \\
 & =\lim\limits_{n \rightarrow \infty}{\dfrac{e^{n}}{c \cdot (c-1) \ldots \cdot n^{c - c}}} = \lim\limits_{n \rightarrow \infty}{\dfrac{e^{n}}{c!}}
 \end{align*}
-Da der Limes $\infty$ ist, folgt daraus das die Funktion $e^{n} \notin \mathcal{O}$ ist (nach der oben genannten Definition.)
+Da der Limes $\infty$ ist, folgt daraus das die Funktion $e^{n} \notin \mathcal{O}(n^c)$ ist (nach der oben genannten Definition.)
 \item  Die Funktion die gegeben ist sieht wie folgt aus:
 \begin{align*}
 \text{log}(n) \notin \Omega(n)
 \end{align*}
-Wie im Hinweis geschrieben, wird der normale Limes betrachtet. 
+Wie im Hinweis geschrieben, werden die Limites von Zähler und Nenner betrachtet.
 \begin{align*}
-\lim\limits_{n \rightarrow \infty}{\dfrac{\text{log}(n)}{n}} \Rightarrow \infty
+\lim\limits_{n \rightarrow \infty}{\text{log}(n)} =
+  \lim\limits_{n \rightarrow \infty}{n} = \infty
 \end{align*}
 Nun wird L'Hospital angewendet.
 \begin{align*}
@@ -170,10 +172,10 @@ Es sei $f(n)$ die Laufzeitfunktion des jeweiligen Algorithmus.
   \subsubsection*{\texttt{Randomized-Search}}
     \begin{description}
       \item[Best-Case] Der erste Index ist nach dem ersten Versuch derjenige von
-        $x$. Also ist in diesem fall wieder $f(n) \in \Theta(1)$. 
+        $x$. Also ist in diesem Fall wieder $f(n) \in \Theta(1)$. 
 
       \item[Worst-Case] Der Wert wird nie gefunden, weil zum Beispiel der
-        Zuf\"allsgenerator in jedem Iterationsschritt 1 ausgibt und 
+        Zufallsgenerator in jedem Iterationsschritt 1 ausgibt und 
         $x$ nicht den ersten Index belegt.
 
       \item[Average-Case] 


### PR DESCRIPTION
Hab die Formulierung bei der Verwendung von LHospital geändert. Man benutzt LHospital ja bei Grenzwerten der Form 0/0 oder \infty/\infty. Außerdem hab ich die Nummerierung der Aufgabenteile vereinheitlicht (dh bei mir (a) durch a) ersetzt) (mit diesem Klammerausdruck kommt kein Kellerautomat zurecht :)) und mir sind ein par Rechtschreibfehler ins Auge gefallen.
